### PR TITLE
add links between home and new pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,7 +31,7 @@ function App() {
             path="/"
             exact
             component={props => (
-              <Home toggleTheme={handleToggleTheme} {...props} />
+              <Home onToggleTheme={handleToggleTheme} {...props} />
             )}
           />
           <Route path="/new" exact component={New} />

--- a/src/components/DarkmodeToggleButton.js
+++ b/src/components/DarkmodeToggleButton.js
@@ -3,23 +3,19 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 
 const ToggleButton = styled.span`
-  height: 22px;
-  width: 22px;
+  height: 30px;
   border-radius: 11px;
   padding: 0px;
   font-size: 20px;
   cursor: pointer;
-  position: absolute;
-  right: 10px;
-  top: 6px;
   &:focus {
     outline: none;
   }
 `;
 
-function DarkmodeToggleButton({ toggleTheme }) {
+function DarkmodeToggleButton({ onToggleTheme }) {
   return (
-    <ToggleButton onClick={toggleTheme}>
+    <ToggleButton onClick={onToggleTheme}>
       <span role="img" aria-label="darkmode toggle">
         🌗
       </span>
@@ -30,5 +26,5 @@ function DarkmodeToggleButton({ toggleTheme }) {
 export default DarkmodeToggleButton;
 
 DarkmodeToggleButton.propTypes = {
-  toggleTheme: PropTypes.func.isRequired
+  onToggleTheme: PropTypes.func.isRequired
 };

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -83,5 +83,6 @@ Modal.propTypes = {
   show: PropTypes.bool,
   hideBackdrop: PropTypes.bool,
   onShow: PropTypes.func,
-  onAccept: PropTypes.func
+  onAccept: PropTypes.func,
+  onClose: PropTypes.func
 };

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -1,20 +1,20 @@
 import React from "react";
 import styled from "styled-components";
 import DarkmodeToggleButton from "./DarkmodeToggleButton";
+import Add from "../icons/Add";
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
 
 const Header = styled.header`
   z-index: 10;
-  flex-shrink: 0;
   height: 40px;
-  width: 100%;
   color: #fff;
   background: ${props => props.theme.main};
-  text-align: center;
   box-shadow: 0 5px 5px ${props => props.theme.shadow};
-  position: relative;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
+  padding: 10px;
 `;
 
 const Headline = styled.h1`
@@ -22,13 +22,27 @@ const Headline = styled.h1`
   font-size: 1.6em;
 `;
 
-function Title({ toggleTheme }) {
+const AddLink = styled(Link)`
+  height: 30px;
+`;
+
+const AddButton = styled(Add)`
+  height: 30px;
+  fill: #fff;
+`;
+
+export default function Title({ onToggleTheme }) {
   return (
     <Header>
+      <AddLink to="/new">
+        <AddButton />
+      </AddLink>
       <Headline>around spaces</Headline>
-      <DarkmodeToggleButton toggleTheme={toggleTheme} />
+      <DarkmodeToggleButton onToggleTheme={onToggleTheme} />
     </Header>
   );
 }
 
-export default Title;
+Title.propTypes = {
+  onToggleTheme: PropTypes.func
+};

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -21,7 +21,7 @@ const StyledFilterBar = styled(FilterBar)`
   padding: 20px 10px;
 `;
 
-export default function Home({ history, location, toggleTheme }) {
+export default function Home({ history, location, onToggleTheme }) {
   const params = new URLSearchParams(location.search);
   const [filters, setFilters] = React.useState({
     category: params.get("category") || "",
@@ -67,7 +67,7 @@ export default function Home({ history, location, toggleTheme }) {
 
   return (
     <>
-      <Title toggleTheme={toggleTheme} />
+      <Title onToggleTheme={onToggleTheme} />
       <StyledFilterBar
         selectedFilters={filters}
         onFilterChange={handleFilterChange}

--- a/src/pages/New.js
+++ b/src/pages/New.js
@@ -20,7 +20,7 @@ const AddCircleIcon = styled(Add)`
   border-radius: 50%;
 `;
 
-export default function New() {
+export default function New({ history }) {
   function handleAccept() {
     postRestaurant({
       imgSrc:
@@ -31,7 +31,11 @@ export default function New() {
       rating: qualityRating,
       priceRating: priceRating,
       description: "Eat italian"
-    });
+    }).then(redirectHome);
+  }
+
+  function redirectHome() {
+    history.push("/");
   }
 
   const [title, setTitle] = useState("");
@@ -50,7 +54,7 @@ export default function New() {
   }
 
   return (
-    <Modal hideBackdrop onAccept={handleAccept}>
+    <Modal hideBackdrop onAccept={handleAccept} onClose={redirectHome}>
       <AddCircleIcon />
       <ModalTitle>Add Restaurant</ModalTitle>
       <ModalSection>Name</ModalSection>


### PR DESCRIPTION
- renamed `toggleTheme` to `onToggleTheme` to clarify that it is an event.
- added an add icon to the header which links to `/new` page. 
- use flex layout in `Title` to position add and theme icons.
- redirect to `/` on new modal close

